### PR TITLE
fix: missing role permissions

### DIFF
--- a/charts/slack/templates/role.yaml
+++ b/charts/slack/templates/role.yaml
@@ -3,44 +3,4 @@ kind: Role
 metadata:
   name: {{ template "fullname" . }}
 rules:
-- apiGroups:
-  - jenkins.io
-  resources:
-  - pipelineactivities
-  verbs:
-  - watch
-  - update
-  - list
-- apiGroups:
-    - jenkins.io
-  resources:
-  - users
-  verbs:
-  - list
-  - create
-  - update
-- apiGroups:
-    - ""
-  resources:
-  - secrets
-  - namespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-    - ""
-  resources:
-    - configmaps
-  resourceNames:
-  - "plugins"
-  verbs:
-    - watch
-    - get
-    - update
-- apiGroups:
-  - slack.app.jenkins-x.io
-  resources:
-  - slackbots
-  verbs:
-  - list
-  - watch
+{{ .Values.role.rules | toYaml }}

--- a/charts/slack/values.yaml
+++ b/charts/slack/values.yaml
@@ -37,3 +37,63 @@ hmacToken:
   name: hmac-token
 
 googleSecretsManager: false
+
+role:
+  rules:
+  - apiGroups:
+    - jenkins.io
+    resources:
+    - pipelineactivities
+    verbs:
+    - watch
+    - update
+    - list
+  - apiGroups:
+    - jenkins.io
+    resources:
+    - environments
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - jenkins.io
+    resources:
+    - users
+    verbs:
+    - list
+    - create
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    - configmaps
+    - namespaces
+    - serviceaccounts
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - "plugins"
+    verbs:
+    - watch
+    - get
+    - update
+  - apiGroups:
+    - slack.app.jenkins-x.io
+    resources:
+    - slackbots
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - vault.banzaicloud.com
+    resources:
+    - vaults
+    verbs:
+    - list
+    - get


### PR DESCRIPTION
- adding missing read permissions on environments, which resulted in the following error

```
WARNING: error loading TeamSettings to determine if in GitHub app mode: failed to setup the dev environment for namespace 'jx': environments.jenkins.io is forbidden: User "system:serviceaccount:jx:jenkins-x-slack" cannot create resource "environments" in API group "jenkins.io" in the namespace "jx"
```

- adding missing read permissions on configmaps, to be able to read git auth config

- move the role rules in the chart values, to allow customization of the rules without requiring updates of the chart